### PR TITLE
newMail bug duzeltmesi

### DIFF
--- a/mailcmd.cpp
+++ b/mailcmd.cpp
@@ -34,9 +34,9 @@ void MailCMD::execute(Ui::MainWindow *window){
 
        Mail newMail;
 
-       newMail.setTo(mParams[1].toStdString());
-       newMail.setSubject(mParams[2].toStdString());
-       newMail.setBody(mParams[3].toStdString());
+       newMail.setTo(mParams[2].toStdString());
+       newMail.setSubject(mParams[3].toStdString());
+       newMail.setBody(mParams[4].toStdString());
 
        GTUVOS::getInstance()->getMailServer().sendMail(newMail);
    }else if(mParams[1].compare("list")==0){


### PR DESCRIPTION
newMail olustururken setTo, setSubject ve setBody kisimlari yanlis parametrelerle calisiyordu (mParams 2 yerine 1, 3 yerine 2 ve 4 yerine 3 vardi sirasiyla)